### PR TITLE
harden: use safe deserialization in Example.java...

### DIFF
--- a/java-enum-hashcode-serialization/src/main/java/com/pivovarit/hash/Example.java
+++ b/java-enum-hashcode-serialization/src/main/java/com/pivovarit/hash/Example.java
@@ -1,16 +1,18 @@
 package com.pivovarit.hash;
 
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 
 class Example {
     static class Serialize {
         void main() throws Exception {
             var map = new SingleEntryMap<>(Type.A, "hello");
-            try (var out = new ObjectOutputStream(new FileOutputStream("/tmp/map.bin"))) {
-                out.writeObject(map);
+            try (var out = new DataOutputStream(new FileOutputStream("/tmp/map.bin"))) {
+                out.writeInt(map.bucket());
+                out.writeUTF(map.key().name());
+                out.writeUTF(map.value());
                 IO.println("Type.A.hashCode() = " + Type.A.hashCode());
             }
         }
@@ -18,8 +20,13 @@ class Example {
 
     static class Deserialize {
         void main() throws Exception {
-            try (var in = new ObjectInputStream(new FileInputStream("/tmp/map.bin"))) {
-                SingleEntryMap<Type, String> map = (SingleEntryMap<Type, String>) in.readObject();
+            // Read only the plain fields we wrote (int + two Strings) instead of
+            // deserializing a full object graph, avoiding unsafe object deserialization.
+            try (var in = new DataInputStream(new FileInputStream("/tmp/map.bin"))) {
+                int bucket = in.readInt();
+                Type key = Type.valueOf(in.readUTF());
+                String value = in.readUTF();
+                var map = new SingleEntryMap<>(bucket, key, value);
 
                 IO.println("Type.A.hashCode() = " + Type.A.hashCode());
                 IO.println("stored bucket     = " + map.bucket());

--- a/java-enum-hashcode-serialization/src/main/java/com/pivovarit/hash/SingleEntryMap.java
+++ b/java-enum-hashcode-serialization/src/main/java/com/pivovarit/hash/SingleEntryMap.java
@@ -15,6 +15,12 @@ class SingleEntryMap<K, V> implements Serializable {
         this.value = value;
     }
 
+    SingleEntryMap(int bucket, K key, V value) {
+        this.bucket = bucket;
+        this.key = key;
+        this.value = value;
+    }
+
     public Optional<V> get(K key) {
         return key.hashCode() == bucket && key.equals(this.key)
           ? Optional.of(value)


### PR DESCRIPTION
## Summary
Harden input handling in `java-enum-hashcode-serialization/src/main/java/com/pivovarit/hash/Example.java` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | java.lang.security.audit.object-deserialization.object-deserialization |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `java.lang.security.audit.object-deserialization.object-deserialization` |
| **File** | `java-enum-hashcode-serialization/src/main/java/com/pivovarit/hash/Example.java:21` |
| **Assessment** | Defensive hardening |

**Description**: Found object deserialization using ObjectInputStream. Deserializing entire Java objects is dangerous because malicious actors can create Java object streams with unintended consequences. Ensure that the objects being deserialized are not user-controlled. If this must be done, consider using HMACs to sign the data stream to make sure it is not tampered with, or consider only transmitting object fields and populating a new object.

## Threat Model Context

This is a Java service - vulnerabilities in servlets/controllers are remotely exploitable.

## Changes
- `java-enum-hashcode-serialization/src/main/java/com/pivovarit/hash/Example.java`
- `java-enum-hashcode-serialization/src/main/java/com/pivovarit/hash/SingleEntryMap.java`

## Behavior Preservation
The change is scoped to 2 files on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
